### PR TITLE
Add path as a parameter

### DIFF
--- a/http/rest/auth.go
+++ b/http/rest/auth.go
@@ -152,6 +152,7 @@ func (rs *AuthResource) AuthCallback(w http.ResponseWriter, r *http.Request) {
 		Value:    newJWT,
 		Expires:  time.Now().Add(time.Hour * 24 * 7),
 		HttpOnly: true,
+		Path: 	  "/"
 	}
 	if viper.GetBool("dev") {
 		seshCookie.Domain = "localhost"


### PR DESCRIPTION
Add the path param so that we can access the cookie anywhere in the domain, instead of just `/api/v2/*`.